### PR TITLE
Add in-memory session validation test

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -10,6 +11,10 @@ sys.path.insert(0, str(ROOT))
 # Stub modules before importing Chat
 sys.modules.setdefault('openai', types.SimpleNamespace(api_key=None))
 sys.modules.setdefault('requests', types.SimpleNamespace())
+
+# Provide dummy API keys so Chat imports without exiting
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DEHASHED_API_KEY", "test")
 
 import Chat
 
@@ -26,3 +31,4 @@ def test_save_session(tmp_path, monkeypatch):
         content = json.load(f)
 
     assert content == {"session1": sample_data}
+    assert Chat.chat_sessions == {"session1": sample_data}


### PR DESCRIPTION
## Summary
- ensure Chat imports without real API keys
- verify Chat.chat_sessions updated when saving session

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d01dcb22c83248d9d6a71b3aae011