### PR TITLE
Fix session file load errors

### DIFF
--- a/Chat.py
+++ b/Chat.py
@@ -20,8 +20,12 @@ openai.api_key = OPENAI_API_KEY
 
 # Initialize or load chat sessions
 if os.path.exists(SESSION_FILE):
-    with open(SESSION_FILE, 'r') as file:
-        chat_sessions = json.load(file)
+    try:
+        with open(SESSION_FILE, 'r') as file:
+            chat_sessions = json.load(file)
+    except json.JSONDecodeError:
+        print("Warning: session file is malformed. Starting with empty sessions.")
+        chat_sessions = {}
 else:
     chat_sessions = {}
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 import types
 from pathlib import Path
+import importlib
+import builtins
 
 # Ensure project root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
@@ -11,10 +14,13 @@ sys.path.insert(0, str(ROOT))
 sys.modules.setdefault('openai', types.SimpleNamespace(api_key=None))
 sys.modules.setdefault('requests', types.SimpleNamespace())
 
-import Chat
-
 
 def test_save_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("DEHASHED_API_KEY", "x")
+    import Chat
+    importlib.reload(Chat)
+
     temp_file = tmp_path / "session.json"
     monkeypatch.setattr(Chat, "SESSION_FILE", str(temp_file))
     monkeypatch.setattr(Chat, "chat_sessions", {})
@@ -26,3 +32,30 @@ def test_save_session(tmp_path, monkeypatch):
         content = json.load(f)
 
     assert content == {"session1": sample_data}
+
+
+def test_malformed_session_file(tmp_path, monkeypatch):
+    invalid = tmp_path / "bad.json"
+    invalid.write_text("{ invalid")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("DEHASHED_API_KEY", "x")
+
+    def fake_exists(path):
+        return True if path == "chat_sessions.json" else os.path.exists(path)
+
+    original_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path == "chat_sessions.json" and "r" in mode:
+            return original_open(invalid, *args, **kwargs)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    import Chat
+    importlib.reload(Chat)
+
+    assert Chat.chat_sessions == {}


### PR DESCRIPTION
## Summary
- handle malformed `chat_sessions.json` gracefully
- patch tests to reload Chat module and configure environment
- add regression test for malformed session file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d01da61c08324ba489691497ad84f